### PR TITLE
Force iOS full screen button in the player bar since default is hidden by desc.

### DIFF
--- a/ios/YouTubeView.swift
+++ b/ios/YouTubeView.swift
@@ -22,7 +22,7 @@ import UIKit
     var lock = false;
     var playerVars:[String: Any] = [
         "controls" : "0",
-        "showinfo" : "0",
+        "showinfo" : "",
         "autoplay": "0",
         "rel": "0",
         "modestbranding": "1",


### PR DESCRIPTION
Credits to [@sikeeoh in issue #14 ](https://github.com/up-inside/react-native-youtube-sdk/issues/14).